### PR TITLE
Do not ever fetch data when refreshing the state of the sensors

### DIFF
--- a/custom_components/open_meteo_solar_forecast/sensor.py
+++ b/custom_components/open_meteo_solar_forecast/sensor.py
@@ -268,15 +268,24 @@ class OpenMeteoSolarForecastSensorEntity(
             configuration_url="https://open-meteo.com",
         )
 
+    async def _update_callback(self, now: datetime) -> None:
+        """Update the entity without fetching data from server.
+
+        This is required for the power_production_* sensors to update
+        as they take data in 15-minute intervals and the update interval
+        is 30 minutes."""
+        self.async_write_ha_state()
+
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()
 
-        # This is required for the power_production_* sensors to update
-        # as they take data in 15-minute intervals and the update interval
-        # is 30 minutes.
+        # Update the state of the sensor every minute without
+        # fetching new data from the server.
         async_track_utc_time_change(
-            self.hass, self.async_schedule_update_ha_state, second=0
+            self.hass,
+            self._update_callback,
+            second=0,
         )
 
     @property


### PR DESCRIPTION
Sometimes, it will fire an API request when attempting to refresh the state of the sensors. This routine is done every minute in order to make sure that the power sensors always have the "earliest" data but fails.

This is most likely why some users are facing rate-limits, coupled with having neighbors that also use Open-Meteo. It explains a lot.