### PR TITLE
Update to open-meteo-solar-forecast 0.1.18

### DIFF
--- a/custom_components/open_meteo_solar_forecast/config_flow.py
+++ b/custom_components/open_meteo_solar_forecast/config_flow.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
@@ -17,10 +13,12 @@ from homeassistant.helpers import config_validation as cv
 from .const import (
     CONF_AZIMUTH,
     CONF_BASE_URL,
+    CONF_DAMPING_EVENING,
+    CONF_DAMPING_MORNING,
     CONF_DECLINATION,
     CONF_EFFICIENCY_FACTOR,
-    CONF_MODULES_POWER,
     CONF_INVERTER_POWER,
+    CONF_MODULES_POWER,
     DOMAIN,
 )
 
@@ -58,6 +56,8 @@ class OpenMeteoSolarForecastFlowHandler(ConfigFlow, domain=DOMAIN):
                     CONF_API_KEY: user_input[CONF_API_KEY],
                     CONF_AZIMUTH: user_input[CONF_AZIMUTH],
                     CONF_BASE_URL: user_input[CONF_BASE_URL],
+                    CONF_DAMPING_MORNING: user_input[CONF_DAMPING_MORNING],
+                    CONF_DAMPING_EVENING: user_input[CONF_DAMPING_EVENING],
                     CONF_DECLINATION: user_input[CONF_DECLINATION],
                     CONF_MODULES_POWER: user_input[CONF_MODULES_POWER],
                     CONF_INVERTER_POWER: user_input[CONF_INVERTER_POWER],
@@ -94,6 +94,8 @@ class OpenMeteoSolarForecastFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_INVERTER_POWER, default=0): vol.All(
                         vol.Coerce(int), vol.Range(min=0)
                     ),
+                    vol.Optional(CONF_DAMPING_MORNING, default=0.0): vol.Coerce(float),
+                    vol.Optional(CONF_DAMPING_EVENING, default=0.0): vol.Coerce(float),
                     vol.Optional(CONF_EFFICIENCY_FACTOR, default=1.0): vol.All(
                         vol.Coerce(float), vol.Range(min=0)
                     ),
@@ -147,6 +149,18 @@ class OpenMeteoSolarForecastOptionFlowHandler(OptionsFlow):
                         CONF_MODULES_POWER,
                         default=self.config_entry.options[CONF_MODULES_POWER],
                     ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(
+                        CONF_DAMPING_MORNING,
+                        default=self.config_entry.options.get(
+                            CONF_DAMPING_MORNING, 0.0
+                        ),
+                    ): vol.Coerce(float),
+                    vol.Optional(
+                        CONF_DAMPING_EVENING,
+                        default=self.config_entry.options.get(
+                            CONF_DAMPING_EVENING, 0.0
+                        ),
+                    ): vol.Coerce(float),
                     vol.Required(
                         CONF_INVERTER_POWER,
                         default=self.config_entry.options.get(CONF_INVERTER_POWER, 0),

--- a/custom_components/open_meteo_solar_forecast/const.py
+++ b/custom_components/open_meteo_solar_forecast/const.py
@@ -11,6 +11,8 @@ CONF_BASE_URL = "base_url"
 CONF_DECLINATION = "declination"
 CONF_AZIMUTH = "azimuth"
 CONF_MODULES_POWER = "modules_power"
+CONF_DAMPING_MORNING = "damping_morning"
+CONF_DAMPING_EVENING = "damping_evening"
 CONF_INVERTER_POWER = "inverter_power"
 CONF_EFFICIENCY_FACTOR = "efficiency_factor"
 

--- a/custom_components/open_meteo_solar_forecast/coordinator.py
+++ b/custom_components/open_meteo_solar_forecast/coordinator.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from open_meteo_solar_forecast import Estimate, OpenMeteoSolarForecast
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from open_meteo_solar_forecast import Estimate, OpenMeteoSolarForecast
+
 from .const import (
     CONF_AZIMUTH,
     CONF_BASE_URL,
+    CONF_DAMPING_EVENING,
+    CONF_DAMPING_MORNING,
     CONF_DECLINATION,
     CONF_EFFICIENCY_FACTOR,
     CONF_INVERTER_POWER,
@@ -52,6 +54,8 @@ class OpenMeteoSolarForecastDataUpdateCoordinator(DataUpdateCoordinator[Estimate
             dc_kwp=(entry.options[CONF_MODULES_POWER] / 1000),
             declination=entry.options[CONF_DECLINATION],
             efficiency_factor=entry.options[CONF_EFFICIENCY_FACTOR],
+            damping_morning=entry.options.get(CONF_DAMPING_MORNING, 0.0),
+            damping_evening=entry.options.get(CONF_DAMPING_EVENING, 0.0),
         )
 
         update_interval = timedelta(minutes=30)

--- a/custom_components/open_meteo_solar_forecast/manifest.json
+++ b/custom_components/open_meteo_solar_forecast/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rany2/ha-open-meteo-solar-forecast/issues",
-  "requirements": ["open_meteo_solar_forecast==0.1.17"],
-  "version": "0.1.15"
+  "requirements": ["open_meteo_solar_forecast==0.1.18"],
+  "version": "0.1.16"
 }

--- a/custom_components/open_meteo_solar_forecast/strings.json
+++ b/custom_components/open_meteo_solar_forecast/strings.json
@@ -6,6 +6,8 @@
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
+          "damping_morning": "Damping factor: adjusts the results in the morning",
+          "damping_evening": "Damping factor: adjusts the results in the evening",
           "declination": "Declination (0 = Horizontal, 90 = Vertical)",
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]",
@@ -27,6 +29,8 @@
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "azimuth": "[%key:component::solar_forecast::config::step::user::data::azimuth%]",
+          "damping_morning": "[%key:component::solar_forecast::config::step::user::data::damping_morning%]",
+          "damping_evening": "[%key:component::solar_forecast::config::step::user::data::damping_evening%]",
           "declination": "[%key:component::solar_forecast::config::step::user::data::declination%]",
           "efficiency_factor": "[%key:component::solar_forecast::config::step::user::data::efficiency_factor%]",
           "modules_power": "[%key:component::solar_forecast::config::step::user::data::modules_power%]",

--- a/custom_components/open_meteo_solar_forecast/translations/en.json
+++ b/custom_components/open_meteo_solar_forecast/translations/en.json
@@ -5,6 +5,8 @@
         "data": {
           "api_key": "API key",
           "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
+          "damping_morning": "Damping factor: adjusts the results in the morning",
+          "damping_evening": "Damping factor: adjusts the results in the evening",
           "declination": "Declination (0 = Horizontal, 90 = Vertical)",
           "latitude": "Latitude",
           "longitude": "Longitude",
@@ -87,6 +89,8 @@
         "data": {
           "api_key": "API key",
           "azimuth": "Azimuth (360 degrees, 0 = North, 90 = East, 180 = South, 270 = West)",
+          "damping_morning": "Damping factor: adjusts the results in the morning",
+          "damping_evening": "Damping factor: adjusts the results in the evening",
           "declination": "Declination (0 = Horizontal, 90 = Vertical)",
           "inverter_size": "Inverter size (Watt)",
           "efficiency_factor": "DC efficiency factor (0.0-1.0, 0.0 = 100% loss, 1.0 = no loss)",


### PR DESCRIPTION
- Improves cell temperature calculation (should reduce over/under-estimations)
- Add damping support for morning and/or evening