### PR TITLE
Add service call to update array location to home location

### DIFF
--- a/custom_components/open_meteo_solar_forecast/__init__.py
+++ b/custom_components/open_meteo_solar_forecast/__init__.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import (
     CONF_AZIMUTH,
@@ -130,6 +130,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    async def async_update_array_location(call: ServiceCall | None = None):
+        new_lat = hass.config.latitude
+        new_lon = hass.config.longitude
+
+        # Updating config entry will automatically update the coordinator
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_LATITUDE: new_lat, CONF_LONGITUDE: new_lon},
+            options={**entry.options, CONF_LATITUDE: new_lat, CONF_LONGITUDE: new_lon},
+        )
+
+    hass.services.async_register(DOMAIN, "update_array_location", async_update_array_location)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/open_meteo_solar_forecast/__init__.py
+++ b/custom_components/open_meteo_solar_forecast/__init__.py
@@ -132,14 +132,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     async def async_update_array_location(call: ServiceCall | None = None):
-        new_lat = hass.config.latitude
-        new_lon = hass.config.longitude
+        new_location = call.data.get("location_override", {
+                "latitude": hass.config.latitude,
+                "longitude": hass.config.longitude,
+        })  # Optional location override defaults to current Home Assistant location
 
         # Updating config entry will automatically update the coordinator
         hass.config_entries.async_update_entry(
             entry,
-            data={**entry.data, CONF_LATITUDE: new_lat, CONF_LONGITUDE: new_lon},
-            options={**entry.options, CONF_LATITUDE: new_lat, CONF_LONGITUDE: new_lon},
+            data={**entry.data, CONF_LATITUDE: new_location["latitude"], CONF_LONGITUDE: new_location["longitude"]},
+            options={**entry.options, CONF_LATITUDE: new_location["latitude"], CONF_LONGITUDE: new_location["longitude"]},
         )
 
     hass.services.async_register(DOMAIN, "update_array_location", async_update_array_location)

--- a/custom_components/open_meteo_solar_forecast/services.yaml
+++ b/custom_components/open_meteo_solar_forecast/services.yaml
@@ -1,0 +1,5 @@
+update_array_location:
+  name: Update Array Location to Home
+  description: >
+    Update the array location to match that of the current GPS coordinates of zone.home
+  fields: {}

--- a/custom_components/open_meteo_solar_forecast/services.yaml
+++ b/custom_components/open_meteo_solar_forecast/services.yaml
@@ -1,5 +1,6 @@
 update_array_location:
-  name: Update Array Location to Home
-  description: >
-    Update the array location to match that of the current GPS coordinates of zone.home
-  fields: {}
+  fields:
+    location_override:
+      required: false
+      selector:
+        location:

--- a/custom_components/open_meteo_solar_forecast/strings.json
+++ b/custom_components/open_meteo_solar_forecast/strings.json
@@ -114,5 +114,17 @@
         "name": "Estimated energy production - next hour"
       }
     }
+  },
+  "services": {
+    "update_array_location": {
+      "name": "Update Array Location",
+      "description": "Update the array location to match that of the provided coordinates, or to the configured HA home location if no coordinates are provided.",
+      "fields": {
+        "location_override": {
+          "name": "Location Override",
+          "description": "Optional location to set the array to, if omitted the array will be set to the HA home location."
+        }
+      }
+    }
   }
 }

--- a/custom_components/open_meteo_solar_forecast/translations/en.json
+++ b/custom_components/open_meteo_solar_forecast/translations/en.json
@@ -113,5 +113,17 @@
         "description": "These values allow tweaking the Solar Forecast result. Please refer to the documentation if a field is unclear."
       }
     }
+  },
+  "services": {
+    "update_array_location": {
+      "name": "Update Array Location",
+      "description": "Update the array location to match that of the provided coordinates, or to the configured HA home location if no coordinates are provided.",
+      "fields": {
+        "location_override": {
+          "name": "Location Override",
+          "description": "Optional location to set the array to, if omitted the array will be set to the HA home location."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This adds a service call (action) to update the lat/lon of the configured array(s) to match that of the configured home location in HA.

### Background:

I switched to this integration because it allows for updating the location without having to reinstall the integration like the core solar forecast requires. However as my HA instance and solar array are on an RV, I'd like to be able to automatically update the location as I travel, and it's not possible to automate changes to the config entry via the config flow alone.


With this change, it's now possible to call `open_meteo_solar_forecast.update_array_location` from an automation triggered by a coordinates change from a GPS device (after calling `homeassistant.set_location` of course)

### Testing:

Tested with my own installation of HA by manually updating the integration via options flow to a wrong lat/lon value, then calling `update_array_location` and noting that the forecast was updated back to the correct forecast, and the next visit to the config flow showed the new/correct lat/lon values