### PR TITLE
Bump ha-open-meteo-solar-forecast version to 0.1.31

### DIFF
--- a/custom_components/open_meteo_solar_forecast/manifest.json
+++ b/custom_components/open_meteo_solar_forecast/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rany2/ha-open-meteo-solar-forecast/issues",
-  "requirements": ["open_meteo_solar_forecast@git+https://github.com/rany2/open-meteo-solar-forecast.git@17b96664ab28e906ea42aaed1cf090b486c9272c"],
-  "version": "0.1.30"
+  "requirements": ["open_meteo_solar_forecast==0.1.31"],
+  "version": "0.1.31"
 }


### PR DESCRIPTION
- New per-array setup wizard: configure each solar array step by step instead of comma-separated fields
- Solar tracker support (horizontal single-axis, vertical single-axis, and dual-axis)
- 15-minute solar energy precision for finer-grained forecasts
- Snow cover can be taken into account in forecast estimates (EXPERIMENTAL)
- Declination and azimuth now accept decimal values (e.g. 22.5°)
- New service call to update an array's location to the home location
- Retained forecast is saved to disk, so it survives Home Assistant restarts
- Fixed retain max age handling
- Clearer validation error message for multi-array setups